### PR TITLE
fix(core): move clear() method to unmount Unity

### DIFF
--- a/lib/core/src/index.ts
+++ b/lib/core/src/index.ts
@@ -199,9 +199,9 @@ class UnityWebgl extends UnityWebglEvent {
 			.then(() => {
 				this._unity = null
 				this._canvas = null
-				this.clear()
 
 				this.emit('unmounted')
+				this.clear()
 			})
 			.catch((err) => {
 				log.error('Unable to Unload Unity')


### PR DESCRIPTION
- Move clear() method to unmount Unity
- This change ensures that the clear() method is called after the Unity instance is properly unloaded